### PR TITLE
Fixed the `.docs/architecture` folder instructions

### DIFF
--- a/.github/instructions/analyze-product.instructions.md
+++ b/.github/instructions/analyze-product.instructions.md
@@ -229,7 +229,7 @@ format: poml
                         - `decisions.md` file
                         - `tech-stack.md` file
                         ` `mission.md` file
-                        - `docs/architecture` folder
+                        - `.docs/architecture` folder
                         - architecture documentation in markdown and mermaid format for each system
                     </hint>
                     <stepwise-instructions>
@@ -262,7 +262,7 @@ format: poml
                             - Hints for replacement in the template are provided in square brackets [].
                             </item>
                             <item>
-                                Create the `docs/architecture` folder. Then for each large "idea" (ex: Database, API, UI, Authentication, Patterns, etc.) in the
+                                Create the `.docs/architecture` folder. Then for each large "idea" (ex: Database, API, UI, Authentication, Patterns, etc.) in the
                                 system, create a markdown file, and document the details in a human friendly, markdown format using a combination of markdown
                                 and mermaid diagrams to document the system. Use the architecture template when building this documentation.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,8 @@
     "chat.instructionsFilesLocations": {
         "instructions": true
     },
+    "chat.checkpoints.enabled": true,
+    "github.copilot.chat.virtualTools.threshold": 90,
     "github.copilot.chat.codeGeneration.useInstructionFiles": true,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
## Description
Fixed the `.docs/architecture` folder instructions

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/formatting changes
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test updates
- [ ] 🔧 Build/CI changes

## Related Issues

## Changes Made
- [x] Changed `analyze-product.instructions.md` to create docs in the `.docs/architecture` folder instead of `docs`
